### PR TITLE
unable to infer complex closure return type; add explicit type to disambiguate

### DIFF
--- a/ios/Classes/helpers/PayPalCallBackHelper.swift
+++ b/ios/Classes/helpers/PayPalCallBackHelper.swift
@@ -53,8 +53,8 @@ class PayPalCallBackHelper {
                 "total": cart.total.toDictionary(),
                 "shippingAddress": cart.shippingAddress?.toDictionary(),
                 "billingAddress": cart.billingAddress?.toDictionary(),
-                "totalAllowedOverCaptureAmount": cart.totalAllowedOverCaptureAmount.toDictionary(),
-                "items": cart.items.map({ (item) in
+                "totalAllowedOverCaptureAmount": cart.totalAllowedOverCaptureAmount.toDictionary() as [String: Any?],
+                "items": cart.items.map({ (item) -> [String: Any?] in
                     var cartItemMap: [String: Any?] = [
                         "name": item.name,
                         "description": item.itemDescription,


### PR DESCRIPTION
fix compilation issue on ios with error "unable to infer complex closure return type; add explicit type to disambiguate"
Added a explicit return type on 'map' and Explicit type casting