### PR TITLE
added namespace on the build.gradle since starting with Android Gradl…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
+    namespace 'com.piccmaq.flutter_paypal_native'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
…e Plugin (AGP) version 7.0.0 and above, a namespace field must be declared in the build.gradl